### PR TITLE
Fr9 map analog

### DIFF
--- a/controller-app/src/App.tsx
+++ b/controller-app/src/App.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 import io from "socket.io-client";
-import LayoutOne from "./pages/LayoutOne";
+// import LayoutOne from "./pages/LayoutOne";
+import LayoutTwo from "./pages/LayoutTwo";
 import { Joystick } from "react-joystick-component";
+
 
 function App() {
   const [socket, setSocket] = useState<SocketIOClient.Socket | null>(null);
@@ -47,7 +49,7 @@ function App() {
   return (
     <>
       {useGamepad ? (
-        socket ? <LayoutOne socket={socket} /> : <p>Connecting...</p>
+        socket ? <LayoutTwo socket={socket} /> : <p>Connecting...</p>
       ) : (
         <Joystick size={100} baseColor="gray" stickColor="blue" move={handleJoystickMove} />
       )}

--- a/controller-app/src/pages/LayoutTwo.tsx
+++ b/controller-app/src/pages/LayoutTwo.tsx
@@ -84,14 +84,14 @@ export default function LayoutTwo({ socket }: LayoutTwoProps) {
   const handleJoystickMove = (joystickId: string, data: any) => {
     if (connected) {
       socket.emit("joystick-move", { joystickId, ...data });
-      console.log(`Joystick ${joystickId} moved:`, data);
+      // console.log(`Joystick ${joystickId} moved:`, data);
     }
   };
 
   const handleJoystickStop = (joystickId: string) => {
     if (connected) {
       socket.emit("joystick-stop", { joystickId });
-      console.log(`Joystick ${joystickId} stopped`);
+      // console.log(`Joystick ${joystickId} stopped`);
     }
   };
 

--- a/controller-app/src/pages/LayoutTwo.tsx
+++ b/controller-app/src/pages/LayoutTwo.tsx
@@ -160,11 +160,11 @@ export default function LayoutTwo({ socket }: LayoutTwoProps) {
             {/* Right Joystick */}
             <div className="flex flex-col items-center">
                 <GameButton 
-                name="options" 
-                label="OPTIONS" 
+                name="select" 
+                label="SELECT" 
                 color="bg-[#4E4848]" 
                 textColor="text-white" 
-                onPress={(isPressed) => handleButtonEvent("options", isPressed)} 
+                onPress={(isPressed) => handleButtonEvent("select", isPressed)} 
                 className="h-[20px] w-[80px] rounded-full px-2 py-1 text-xs" 
                 />
                 <div className="mb-1 text-white text-xs translate-y-12 translate-x-10">Right</div>

--- a/controller-app/src/pages/LayoutTwo.tsx
+++ b/controller-app/src/pages/LayoutTwo.tsx
@@ -72,6 +72,10 @@ export default function LayoutTwo({ socket }: LayoutTwoProps) {
 
   const handleButtonEvent = (buttonId: string, isPressed: boolean) => {
     if (connected) {
+
+      // Haptics for button press (Only works for Chrome and Edge)
+      navigator.vibrate(75);
+
       socket.emit("button", { button: buttonId, pressed: isPressed });
       console.log(`Button ${buttonId} ${isPressed ? "pressed" : "released"}`);
     }
@@ -90,6 +94,13 @@ export default function LayoutTwo({ socket }: LayoutTwoProps) {
       console.log(`Joystick ${joystickId} stopped`);
     }
   };
+
+  // Haptics for when joystick starts moving, for Chrome and Edge only
+  const handleJoystickStart = () => {
+    if (connected) {
+      navigator.vibrate(75);
+    }
+  }
 
   if (!isLandscape) {
     return (
@@ -133,7 +144,7 @@ export default function LayoutTwo({ socket }: LayoutTwoProps) {
           </div>
 
           {/* Center - Start/Options buttons */}
-          <div className="flex flex-row items-center justify-center gap-8 translate-y-1/2">
+          <div className="flex flex-row items-center justify-center gap-8 translate-y-1/3">
             {/* Left Joystick */}
           <div className="flex flex-col items-center">
                 <GameButton 
@@ -145,14 +156,15 @@ export default function LayoutTwo({ socket }: LayoutTwoProps) {
                     className="h-[20px] w-[80px] rounded-full px-2 py-1 text-xs" 
                     />
                 
-                <div className="mb-1 text-white text-xs translate-y-12 -translate-x-10">Left</div>
-                <div className="h-24 w-24 flex items-center justify-center translate-y-12 -translate-x-10">
+                <div className="mb-1 text-white text-xs translate-y-10 -translate-x-10">Left</div>
+                <div className="h-24 w-24 flex items-center justify-center translate-y-10 -translate-x-10">
                 <Joystick 
-                    size={80} 
+                    size={90} 
                     baseColor="#333333" 
                     stickColor="#666666" 
                     move={(data) => handleJoystickMove("left-analog", data)} 
                     stop={() => handleJoystickStop("left-analog")}
+                    start={() => handleJoystickStart()}
                 />
             </div>
           </div>
@@ -167,14 +179,15 @@ export default function LayoutTwo({ socket }: LayoutTwoProps) {
                 onPress={(isPressed) => handleButtonEvent("select", isPressed)} 
                 className="h-[20px] w-[80px] rounded-full px-2 py-1 text-xs" 
                 />
-                <div className="mb-1 text-white text-xs translate-y-12 translate-x-10">Right</div>
-                <div className="h-24 w-24 flex items-center justify-center translate-y-12 translate-x-10">
+                <div className="mb-1 text-white text-xs translate-y-10 translate-x-10">Right</div>
+                <div className="h-24 w-24 flex items-center justify-center translate-y-10 translate-x-10">
                 <Joystick 
-                    size={80} 
+                    size={90} 
                     baseColor="#333333" 
                     stickColor="#666666" 
                     move={(data) => handleJoystickMove("right-analog", data)} 
                     stop={() => handleJoystickStop("right-analog")}
+                    start={() => handleJoystickStart()}
                 />
                 </div>
             </div>

--- a/controller-app/src/pages/LayoutTwo.tsx
+++ b/controller-app/src/pages/LayoutTwo.tsx
@@ -151,8 +151,8 @@ export default function LayoutTwo({ socket }: LayoutTwoProps) {
                     size={80} 
                     baseColor="#333333" 
                     stickColor="#666666" 
-                    move={(data) => handleJoystickMove("left", data)} 
-                    stop={() => handleJoystickStop("left")}
+                    move={(data) => handleJoystickMove("left-analog", data)} 
+                    stop={() => handleJoystickStop("left-analog")}
                 />
             </div>
           </div>
@@ -173,8 +173,8 @@ export default function LayoutTwo({ socket }: LayoutTwoProps) {
                     size={80} 
                     baseColor="#333333" 
                     stickColor="#666666" 
-                    move={(data) => handleJoystickMove("right", data)} 
-                    stop={() => handleJoystickStop("right")}
+                    move={(data) => handleJoystickMove("right-analog", data)} 
+                    stop={() => handleJoystickStop("right-analog")}
                 />
                 </div>
             </div>

--- a/controller-app/src/pages/LayoutTwo.tsx
+++ b/controller-app/src/pages/LayoutTwo.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import GameButton from "../components/GameButton";
+import { DPad } from "../components/DPad";
+import { Joystick } from "react-joystick-component";
+
+interface LayoutTwoProps {
+  socket: SocketIOClient.Socket;
+}
+
+function getDeviceType(socket: SocketIOClient.Socket) {
+  const ua = navigator.userAgent;
+  let deviceType = "";
+
+  if (/android/i.test(ua)) {
+    deviceType = "Android Device";
+  } else if (/iPhone|iPad|iPod/i.test(ua)) {
+    deviceType = "iOS Device";
+  } else {
+    deviceType = "Unknown Device Type";
+  }
+
+  return `${deviceType} | Socket ID - ${socket.id}`;
+}
+
+export default function LayoutTwo({ socket }: LayoutTwoProps) {
+  const [connected, setConnected] = useState(false);
+  const [isLandscape, setIsLandscape] = useState(false);
+  const [manuallyDisconnected, setManuallyDisconnected] = useState(false);
+  const [maxConnections, setMaxConnections] = useState(false);
+
+  useEffect(() => {
+    const handleConnect = () => setConnected(true);
+    const handleDisconnect = () => setConnected(false);
+    const handleManualDisconnect = () => setManuallyDisconnected(true);
+    const handleMaxConnections = () => setMaxConnections(true);
+
+    const sendDeviceInfo = () => {
+      const deviceName = getDeviceType(socket);
+      socket.emit('device-info', { deviceName: deviceName });
+    };
+
+    socket.on("connect", handleConnect);
+    socket.on("disconnect", handleDisconnect);
+    socket.on("request-device-info", sendDeviceInfo);
+    socket.on("max-connections-reached", handleMaxConnections)
+    socket.on("manually-disconnect", handleManualDisconnect)
+
+    // Check and update orientation
+    const checkOrientation = () => {
+      setIsLandscape(window.innerWidth > window.innerHeight);
+    };
+    
+    // Initial check
+    checkOrientation();
+    
+    // Listen for orientation changes
+    window.addEventListener('resize', checkOrientation);
+    window.addEventListener('orientationchange', checkOrientation);
+
+    return () => {
+      socket.off("connect", handleConnect);
+      socket.off("disconnect", handleDisconnect);
+      socket.off("request-device-info", sendDeviceInfo);
+      socket.off("max-connections-reached", handleMaxConnections);
+      socket.off("manually-disconnect", handleManualDisconnect);
+      window.removeEventListener('resize', checkOrientation);
+      window.removeEventListener('orientationchange', checkOrientation);
+    };
+  }, [socket]);
+
+  const handleButtonEvent = (buttonId: string, isPressed: boolean) => {
+    if (connected) {
+      socket.emit("button", { button: buttonId, pressed: isPressed });
+      console.log(`Button ${buttonId} ${isPressed ? "pressed" : "released"}`);
+    }
+  };
+
+  const handleJoystickMove = (joystickId: string, data: any) => {
+    if (connected) {
+      socket.emit("joystick-move", { joystickId, ...data });
+      console.log(`Joystick ${joystickId} moved:`, data);
+    }
+  };
+
+  const handleJoystickStop = (joystickId: string) => {
+    if (connected) {
+      socket.emit("joystick-stop", { joystickId });
+      console.log(`Joystick ${joystickId} stopped`);
+    }
+  };
+
+  if (!isLandscape) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-90 text-white p-4 z-50">
+        <div className="text-center">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-12 w-12 mx-auto mb-2 animate-pulse" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v7h7V4H4zm9 0v7h7V4h-7zm-9 9v7h7v-7H4zm9 0v7h7v-7h-7z" />
+          </svg>
+          <h2 className="text-xl font-bold mb-2">Please Rotate Your Device</h2>
+          <p>This controller is designed for landscape orientation.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 bg-gray-900 w-full h-full overflow-hidden">
+      <div className={`absolute top-2 right-2 flex items-center gap-2 ${connected ? "text-green-500" : "text-red-500"}`}>
+        <div className={`h-3 w-3 rounded-full ${connected ? "bg-green-500" : "bg-red-500"}`}></div>
+        <span className="text-sm">
+          {maxConnections
+            ? "Max connections currently connected. You have been disconnected. You may now close this window."
+            : connected
+              ? `${getDeviceType(socket)}: Connected`
+              : manuallyDisconnected
+                ? "Manually Disconnected. You may now close this window."
+                : "Disconnected"
+          }
+        </span>
+      </div>
+
+      <div className=" flex flex-col space-y-0">
+        {/* Top section - Controls shifted up */}
+        <div className="flex-1 flex flex-row items-start justify-between p-2 pt-6">
+          {/* Left side - D-Pad */}
+          <div className="flex-1 flex justify-center items-center">
+            {/* Scale down the DPad by wrapping it in a smaller container */}
+            <div className="transform scale-75 origin-top-left translate-x-5 translate-y-5">
+              <DPad onDirectionPress={handleButtonEvent} />
+            </div>
+          </div>
+
+          {/* Center - Start/Options buttons */}
+          <div className="flex flex-row items-center justify-center gap-8 translate-y-1/2">
+            {/* Left Joystick */}
+          <div className="flex flex-col items-center">
+                <GameButton 
+                    name="start" 
+                    label="START" 
+                    color="bg-[#4E4848]" 
+                    textColor="text-white" 
+                    onPress={(isPressed) => handleButtonEvent("start", isPressed)} 
+                    className="h-[20px] w-[80px] rounded-full px-2 py-1 text-xs" 
+                    />
+                
+                <div className="mb-1 text-white text-xs translate-y-12 -translate-x-10">Left</div>
+                <div className="h-24 w-24 flex items-center justify-center translate-y-12 -translate-x-10">
+                <Joystick 
+                    size={80} 
+                    baseColor="#333333" 
+                    stickColor="#666666" 
+                    move={(data) => handleJoystickMove("left", data)} 
+                    stop={() => handleJoystickStop("left")}
+                />
+            </div>
+          </div>
+
+            {/* Right Joystick */}
+            <div className="flex flex-col items-center">
+                <GameButton 
+                name="options" 
+                label="OPTIONS" 
+                color="bg-[#4E4848]" 
+                textColor="text-white" 
+                onPress={(isPressed) => handleButtonEvent("options", isPressed)} 
+                className="h-[20px] w-[80px] rounded-full px-2 py-1 text-xs" 
+                />
+                <div className="mb-1 text-white text-xs translate-y-12 translate-x-10">Right</div>
+                <div className="h-24 w-24 flex items-center justify-center translate-y-12 translate-x-10">
+                <Joystick 
+                    size={80} 
+                    baseColor="#333333" 
+                    stickColor="#666666" 
+                    move={(data) => handleJoystickMove("right", data)} 
+                    stop={() => handleJoystickStop("right")}
+                />
+                </div>
+            </div>
+          </div>
+
+          {/* Right side - Action buttons */}
+          <div className="flex-1 flex justify-center items-center translate-y-4">
+            <div className="relative h-[180px] w-[180px]">
+              <div className="absolute left-1/2 top-2 -translate-x-1/2">
+                <GameButton 
+                  name="y" 
+                  label="Y" 
+                  color="bg-[#807300]" 
+                  onPress={(isPressed) => handleButtonEvent("y", isPressed)} 
+                  className="h-[60px] w-[60px] rounded-full" 
+                />
+              </div>
+              <div className="absolute right-2 top-1/2 -translate-y-1/2">
+                <GameButton 
+                  name="b" 
+                  label="B" 
+                  color="bg-[#A90202]" 
+                  onPress={(isPressed) => handleButtonEvent("b", isPressed)} 
+                  className="h-[60px] w-[60px] rounded-full" 
+                />
+              </div>
+              <div className="absolute bottom-2 left-1/2 -translate-x-1/2">
+                <GameButton 
+                  name="a" 
+                  label="A" 
+                  color="bg-[#00802F]" 
+                  onPress={(isPressed) => handleButtonEvent("a", isPressed)} 
+                  className="h-[60px] w-[60px] rounded-full" 
+                />
+              </div>
+              <div className="absolute left-2 top-1/2 -translate-y-1/2">
+                <GameButton 
+                  name="x" 
+                  label="X" 
+                  color="bg-[#001880]" 
+                  onPress={(isPressed) => handleButtonEvent("x", isPressed)} 
+                  className="h-[60px] w-[60px] rounded-full" 
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop-app/src/electron/controller-inputs/AnaogInput.ts
+++ b/desktop-app/src/electron/controller-inputs/AnaogInput.ts
@@ -4,12 +4,16 @@ import {keyboard, mouse, Point, screen} from "@nut-tree-fork/nut-js"
 keyboard.config.autoDelayMs = 0;
 mouse.config.autoDelayMs = 0;
 
-
+// Coordinates correspond to joystick x,y
+// Point corresponds to mouse x,y
 
 export class AnalogInput extends ControllerInput {
     private sensitivity = 15;
-    private deadzone = 0.07;
+    private deadzone = 0.15;
     private lastPosition: Point = {x:0,y:0};
+    private currentPosition: Coordinates = {x:0, y:0};
+    private moveInterval: NodeJS.Timeout | null = null;
+    private isMoving: boolean = false;
     private screenWidth: number = 1600;
     private screenHeight: number = 900;
     constructor(id: string, mappingTarget: MouseMotionTarget | KeyboardTarget) {
@@ -26,27 +30,62 @@ export class AnalogInput extends ControllerInput {
 
     async handleInput(position: Coordinates): Promise<void> {
         console.log(position);
-        if (this.mappingTarget.type == "mouseMotion") {
-            await this.handleMouseMotionInput(position);
-        }
 
-    }
-
-    private async handleMouseMotionInput(position: Coordinates) {
-        if (Math.abs(position.x) < this.deadzone) {
+        // Apply Deadzone
+        if (Math.abs(position.x) <= this.deadzone) {
             position.x = 0;
         }
-        if (Math.abs(position.y) < this.deadzone) {
+        if (Math.abs(position.y) <= this.deadzone) {
             position.y = 0;
         }
 
+        this.currentPosition = position;
+        
+        // Need the stopMotion to stop the interval
+        if (!this.isMoving) {
+            this.startMotion();
+        } else if (this.currentPosition.x===0 && this.currentPosition.y===0) {
+            this.stopMotion();
+        }
+
+
+    }
+
+    async startMotion(): Promise<void> {
+        // Clear any existing interval to avoid multiple intervals
+        if (this.moveInterval) {
+            clearInterval(this.moveInterval);
+        }
+
+        this.isMoving = true;
+        
+        // Set up interval for continuous movement
+        this.moveInterval = setInterval(async () => {
+            if (this.mappingTarget.type === "mouseMotion") {
+                await this.handleMouseMotionInput();
+            } else if (this.mappingTarget.type === "keyboard") {
+                await this.handleKeyboardInput();
+            }
+        }, 16); // ~60fps updates
+    } 
+
+    stopMotion(): void {
+        this.isMoving = false
+        if (this.moveInterval) {
+            clearInterval(this.moveInterval);
+        }
+        this.currentPosition = {x:0,y:0};
+    }
+
+    private async handleMouseMotionInput() {
+
         this.lastPosition = await mouse.getPosition();
 
-        position.x*=this.sensitivity;
-        position.y*=this.sensitivity;
+        // position.x*=this.sensitivity;
+        // position.y*=this.sensitivity;
 
-        const point_x = Math.max(Math.min(this.lastPosition.x + position.x, this.screenWidth), 0)
-        const point_y = Math.max(Math.min(this.lastPosition.y - position.y, this.screenHeight), 0)
+        const point_x = Math.max(Math.min(this.lastPosition.x + this.currentPosition.x*this.sensitivity, this.screenWidth), 0)
+        const point_y = Math.max(Math.min(this.lastPosition.y - this.currentPosition.y*this.sensitivity, this.screenHeight), 0)
 
         const point = new Point(point_x, point_y)
 
@@ -61,5 +100,9 @@ export class AnalogInput extends ControllerInput {
         if (sensitivity > 0) {
             this.sensitivity = sensitivity;
         }
+    }
+
+    private async handleKeyboardInput() {
+
     }
 }

--- a/desktop-app/src/electron/controller-inputs/AnaogInput.ts
+++ b/desktop-app/src/electron/controller-inputs/AnaogInput.ts
@@ -1,0 +1,65 @@
+import { KeyboardTarget, MouseMotionTarget, Coordinates } from "../../types.js";
+import { ControllerInput } from "./ControllerInput.js";
+import {keyboard, mouse, Point, screen} from "@nut-tree-fork/nut-js"
+keyboard.config.autoDelayMs = 0;
+mouse.config.autoDelayMs = 0;
+
+
+
+export class AnalogInput extends ControllerInput {
+    private sensitivity = 15;
+    private deadzone = 0.07;
+    private lastPosition: Point = {x:0,y:0};
+    private screenWidth: number = 1600;
+    private screenHeight: number = 900;
+    constructor(id: string, mappingTarget: MouseMotionTarget | KeyboardTarget) {
+        super(id, mappingTarget)
+    }
+
+    async setScreenDimensions() {
+        this.screenWidth = await screen.width();
+        this.screenHeight = await screen.height();
+
+        console.log(this.screenHeight);
+        console.log(this.screenWidth);
+    }
+
+    async handleInput(position: Coordinates): Promise<void> {
+        console.log(position);
+        if (this.mappingTarget.type == "mouseMotion") {
+            await this.handleMouseMotionInput(position);
+        }
+
+    }
+
+    private async handleMouseMotionInput(position: Coordinates) {
+        if (Math.abs(position.x) < this.deadzone) {
+            position.x = 0;
+        }
+        if (Math.abs(position.y) < this.deadzone) {
+            position.y = 0;
+        }
+
+        this.lastPosition = await mouse.getPosition();
+
+        position.x*=this.sensitivity;
+        position.y*=this.sensitivity;
+
+        const point_x = Math.max(Math.min(this.lastPosition.x + position.x, this.screenWidth), 0)
+        const point_y = Math.max(Math.min(this.lastPosition.y - position.y, this.screenHeight), 0)
+
+        const point = new Point(point_x, point_y)
+
+        // mouse.move(straightTo(point));
+        mouse.setPosition(point);
+
+        this.lastPosition.x = point_x;
+        this.lastPosition.y = point_y;
+    }
+
+    setSensitivity(sensitivity: number): void {
+        if (sensitivity > 0) {
+            this.sensitivity = sensitivity;
+        }
+    }
+}

--- a/desktop-app/src/electron/controller-inputs/AnaogInput.ts
+++ b/desktop-app/src/electron/controller-inputs/AnaogInput.ts
@@ -16,6 +16,8 @@ export class AnalogInput extends ControllerInput {
     private isMoving: boolean = false;
     private screenWidth: number = 1600;
     private screenHeight: number = 900;
+    private isXMoving: boolean = false;
+    private isYMoving: boolean = false;
     constructor(id: string, mappingTarget: MouseMotionTarget | AnalogKeyboardTarget) {
         super(id, mappingTarget)
     }
@@ -29,7 +31,7 @@ export class AnalogInput extends ControllerInput {
     }
 
     async handleInput(position: Coordinates): Promise<void> {
-        console.log(position);
+        // console.log(position);
 
         // Apply Deadzone
         if (Math.abs(position.x) <= this.deadzone) {
@@ -95,22 +97,44 @@ export class AnalogInput extends ControllerInput {
     private async handleKeyboardInput() {
         const {positiveX, positiveY, negativeX, negativeY} = this.mappingTarget as AnalogKeyboardTarget
         if (this.currentPosition.x === 0) {
-            await keyboard.releaseKey(...positiveX, ...negativeX);
+            await keyboard.releaseKey(...positiveX);
+            await keyboard.releaseKey(...negativeX);
+            this.isXMoving = false;
         }
         if (this.currentPosition.y === 0) {
-            await keyboard.releaseKey(...positiveY, ...negativeY);
+            await keyboard.releaseKey(...positiveY);
+            await keyboard.releaseKey(...negativeY);
+            this.isYMoving = false;
         }
 
-        if (this.currentPosition.x > this.deadzone) {
-            await keyboard.pressKey(...positiveX);
-        } else if (this.currentPosition.x < -this.deadzone) {
-            await keyboard.pressKey(...negativeX);
+        if (this.currentPosition.x === 0 && this.currentPosition.y === 0) {
+            return;
         }
 
-        if (this.currentPosition.y > this.deadzone) {
-            await keyboard.pressKey(...positiveY);
-        } else if (this.currentPosition.y < -this.deadzone) {
-            await keyboard.pressKey(...negativeY);
+        if (!this.isXMoving) {
+            if (this.currentPosition.x!==0) {
+                this.isXMoving = true;
+            }
+            if (this.currentPosition.x > 0) {
+                await keyboard.releaseKey(...positiveX);
+                await keyboard.pressKey(...positiveX);
+            } else if (this.currentPosition.x < 0) {
+                await keyboard.releaseKey(...negativeX);
+                await keyboard.pressKey(...negativeX);
+            }
+        }
+        
+        if (!this.isYMoving) {
+            if (this.currentPosition.y!==0) {
+                this.isYMoving = true;
+            }
+            if (this.currentPosition.y > 0) {
+                await keyboard.releaseKey(...positiveY);
+                await keyboard.pressKey(...positiveY);
+            } else if (this.currentPosition.y < 0) {
+                await keyboard.releaseKey(...negativeY);
+                await keyboard.pressKey(...negativeY);
+            }
         }
         
     }

--- a/desktop-app/src/electron/controller-inputs/ButtonInput.ts
+++ b/desktop-app/src/electron/controller-inputs/ButtonInput.ts
@@ -2,6 +2,7 @@ import { KeyboardTarget, MouseClickTarget } from "../../types.js";
 import { ControllerInput } from "./ControllerInput.js";
 import {keyboard, mouse} from "@nut-tree-fork/nut-js";
 keyboard.config.autoDelayMs = 0;
+mouse.config.autoDelayMs = 0;
 
 export class ButtonInput extends ControllerInput {
     constructor(id: string, mappingTarget: KeyboardTarget | MouseClickTarget) {

--- a/desktop-app/src/electron/main.ts
+++ b/desktop-app/src/electron/main.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { getPreloadPath } from './pathResolver.js';
 import { serveControllerApp } from './server.js';
 import { ControllerLayout } from './controllers/ControllerLayout.js';
-import { KeyboardTarget, Mapping, MouseClickTarget, MouseMotionTarget, Coordinates } from '../types.js';
+import { KeyboardTarget, Mapping, MouseClickTarget, MouseMotionTarget, Coordinates, AnalogKeyboardTarget } from '../types.js';
 import {Button, Key} from '@nut-tree-fork/nut-js'
 import { ButtonInput } from './controller-inputs/ButtonInput.js';
 import { ipcMain } from 'electron';
@@ -66,7 +66,15 @@ let mappingsLayoutA: Mapping[] = [
     {
         id: 'right-analog',
         source: 'analog',
-        target: {type: 'mouseMotion', sensitivity: 25}
+        target: {type: 'mouseMotion', sensitivity: 15}
+    },
+    {
+        id: 'left-analog',
+        source: 'analog',
+        target: {type: 'analogKeyboard', 
+            positiveX: [Key.D], positiveY: [Key.W], 
+            negativeX: [Key.A], negativeY: [Key.S]
+        }
     }
 ]
 
@@ -91,8 +99,8 @@ const initializeControllerA = async (controller: ControllerLayout, mappings: Map
                 analogInput.setSensitivity(mapping.target.sensitivity);
                 await analogInput.setScreenDimensions();
                 controller.addInput(analogInput);
-            } else if (mapping.target.type === 'keyboard') {
-                const analogInput = new AnalogInput(mapping.id, mapping.target as KeyboardTarget);
+            } else if (mapping.target.type === 'analogKeyboard') {
+                const analogInput = new AnalogInput(mapping.id, mapping.target as AnalogKeyboardTarget);
                 controller.addInput(analogInput);
             }
         }

--- a/desktop-app/src/electron/main.ts
+++ b/desktop-app/src/electron/main.ts
@@ -172,6 +172,11 @@ app.on("ready", async () => {
                 await controllerLayout.inputs.get(data.joystickId)?.handleInput(joystickCoordinates)
             });
 
+            socket.on('joystick-stop', async (data) => {
+                console.log('Joystick stopped:', data);
+                await controllerLayout.inputs.get(data.joystickId)?.handleInput({x:0, y:0});
+            });
+
             socket.on('button', async (data: {button: string, pressed: boolean}) =>{
                 console.log(data.pressed);
                 await controllerLayout.inputs.get(data.button)?.handleInput(data.pressed)

--- a/desktop-app/src/types.d.ts
+++ b/desktop-app/src/types.d.ts
@@ -26,6 +26,12 @@ interface Mapping {
     iconPath?: string;
 }
 
+type Coordinates = {
+    x: number;
+    y: number;
+}
+
+
 // To make IPC typesafe
 type EventPayloadMapping = {
     getControllerMappings: Mapping[];

--- a/desktop-app/src/types.d.ts
+++ b/desktop-app/src/types.d.ts
@@ -2,7 +2,7 @@ import {Key, Button} from "@nut-tree-fork/nut-js";
 
 type InputType = 'button' | 'analog' | 'motion' | 'voice'
 
-type OutputTarget = KeyboardTarget | MouseClickTarget | MouseMotionTarget
+type OutputTarget = KeyboardTarget | MouseClickTarget | MouseMotionTarget | AnalogKeyboardTarget
 
 interface KeyboardTarget {
     type: 'keyboard';
@@ -17,6 +17,14 @@ interface MouseClickTarget {
 interface MouseMotionTarget {
     type: 'mouseMotion';
     sensitivity: number;
+}
+
+interface AnalogKeyboardTarget {
+    type: 'analogKeyboard';
+    positiveX: Key[];
+    positiveY: Key[];
+    negativeX: Key[];
+    negativeY: Key[];
 }
 
 interface Mapping {

--- a/desktop-app/src/ui/components/customizeModal.tsx
+++ b/desktop-app/src/ui/components/customizeModal.tsx
@@ -117,7 +117,7 @@ function CustomizeModal ({ isOpen, onClose, mappings, selectedMapping, onSave }:
           ) : (
             <div className="space-y-4">
               <h3 className="text-lg font-medium">Keyboard Customization</h3>
-              <p>Select a key on the keyboard to customize its mapping.</p>
+              <p>Select upto 3 keys on the keyboard to bind to chosen button.</p>
               
               {/* Keyboard Component */}
               <div className="bg-neutral-800 rounded-md p-4">
@@ -134,12 +134,12 @@ function CustomizeModal ({ isOpen, onClose, mappings, selectedMapping, onSave }:
         <div className="flex justify-end space-x-2 p-4 border-t border-neutral-700">
           <button 
             onClick={onClose}
-            className="px-4 py-2 bg-neutral-700 text-white rounded-md hover:bg-neutral-600"
+            className="px-4 py-2 bg-neutral-700 text-white rounded-md hover:bg-neutral-600 hover:cursor-pointer"
           >
             Cancel
           </button>
           <button 
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-500"
+            className="px-4 py-2 bg-red-700 text-white rounded-md hover:cursor-pointer hover:bg-red-500"
             onClick={handleSave}
           >
             Save Changes

--- a/desktop-app/src/ui/pages/connections.tsx
+++ b/desktop-app/src/ui/pages/connections.tsx
@@ -81,7 +81,7 @@ function Connections() {
         </div>
 
         <button
-          className="mt-4 px-8 py-4 bg-blue-600 text-white text-xl font-semibold rounded-lg shadow-lg hover:bg-red-700 transition-colors duration-300 transform hover:scale-105"
+          className="px-8 py-4 bg-neutral-900 text-white text-xl font-semibold rounded-lg hover:border-red-700 hover:border shadow-lg transform hover:scale-105 cursor-pointer"
           onClick={() => navigate('/customize')}
         >
           Back to customize

--- a/desktop-app/src/ui/pages/customize.tsx
+++ b/desktop-app/src/ui/pages/customize.tsx
@@ -145,7 +145,8 @@ function Customize() {
                                 }`}>
                                     {mapping.target.type === 'keyboard' ? 'Keyboard' : 
                                     mapping.target.type === 'mouseClick' ? 'Mouse Click' : 
-                                    'Mouse Motion'}
+                                    mapping.target.type === 'mouseMotion' ? 'Mouse Motion':
+                                    'Analog Keyboard'}
                                 </span>
                             </div>
                             {mapping.target.type === 'keyboard' && renderKeyBindings(mapping.target.keybinding)}


### PR DESCRIPTION
- Maps analog to mouse motion (hardcoded sensitivity right now)
- Maps analog to keys (hardcoded keys right now)
- Adds Haptic feedback (vibrations) to button presses and start of analog motions (only works on chrome/edge I think)
- DOES NOT yet handle customizing analog to mouse mapping (basically just setting sensitivity) or analog to key mapping. The customization feature will be included in a different PR

- I've implemented a few steps for smoother analog to key/mouse control and they work reasonably well, but further improvements can definitely be added if needed